### PR TITLE
商品削除機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -37,8 +37,10 @@ class ItemsController < ApplicationController
   end
 
   def destroy
-    @item.destroy
-    redirect_to root_path
+    if @item.user == current_user
+        @item.destroy
+      redirect_to root_path
+    end
 
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :edit]
-  before_action :set_item, only: [:show, :edit, :update]
+  before_action :set_item, only: [:show, :edit, :update, :destroy]
 
   def index
     @items = Item.order(created_at: :desc)
@@ -37,7 +37,6 @@ class ItemsController < ApplicationController
   end
 
   def destroy
-    @item = Item.find(params[:id])
     @item.destroy
     redirect_to root_path
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -35,6 +35,7 @@ class ItemsController < ApplicationController
 
   def destroy
     @item.destroy
+    redirect_to root_path
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :edit]
   before_action :set_item, only: [:show, :edit, :update, :destroy]
-
+  before_action :move_to_index, only: [:edit, :destroy]
   def index
     @items = Item.order(created_at: :desc)
   end
@@ -23,9 +23,6 @@ class ItemsController < ApplicationController
   end
 
   def edit 
-      unless @item.user == current_user
-        redirect_to root_path
-      end
   end
 
   def update
@@ -37,11 +34,7 @@ class ItemsController < ApplicationController
   end
 
   def destroy
-    if @item.user == current_user
-        @item.destroy
-      redirect_to root_path
-    end
-
+    @item.destroy
   end
 
   private
@@ -53,5 +46,11 @@ class ItemsController < ApplicationController
 
   def set_item
     @item = Item.find(params[:id])
+  end
+
+  def move_to_index
+    unless @item.user == current_user
+      redirect_to root_path
+    end
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -36,6 +36,13 @@ class ItemsController < ApplicationController
     end
   end
 
+  def destroy
+    @item = Item.find(params[:id])
+    @item.destroy
+    redirect_to root_path
+
+  end
+
   private
 
   def item_params

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -31,7 +31,7 @@
       <% if current_user.id == @item.user_id %>
         <%= link_to "商品の編集", edit_item_path(@item), method: :get, class: "item-red-btn" %>
           <p class=“or-text”>or</p>
-        <%= link_to "削除", "#", data: {turbo_method: :delete}, class: "item-destroy" %>
+        <%= link_to "削除", item_path(@item), data: {turbo_method: :delete}, class: "item-destroy" %>
       <% else %>
       <%# 自身が出品していない販売中の商品かつ売却済みでない場合 %>
         <%# 売却済みでない場合のみ「購入画面に進む」ボタンを表示 %>


### PR DESCRIPTION
# WHAT
出品した商品を削除できるように実装

# WHY
商品情報を削除する機能は、効率的な運営と顧客満足度を高めるため
売り切れた商品や販売を終了した商品を削除することで顧客に最新の情報を提供します。
また、誤って登録された商品や不適切な内容の商品情報を削除することで、サイトの信頼性を保つことができます。

■ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
https://gyazo.com/1567ec92cd3728a4d42237b2ec2860c4