### PR TITLE
複数枚画像投稿の実装

### DIFF
--- a/app/assets/stylesheets/items/new.css
+++ b/app/assets/stylesheets/items/new.css
@@ -227,3 +227,12 @@
 .inc {
   font-size: 13px;
 }
+
+.image-delete-button {
+  text-align: center;
+  border: solid 1px;
+  cursor: pointer;
+  margin-bottom: 5px;
+  width: 80px;
+  margin: 10px auto;
+}

--- a/app/assets/stylesheets/items/new.css
+++ b/app/assets/stylesheets/items/new.css
@@ -236,3 +236,7 @@
   width: 80px;
   margin: 10px auto;
 }
+
+.previews {
+  display: flex;
+}

--- a/app/assets/stylesheets/items/show.css
+++ b/app/assets/stylesheets/items/show.css
@@ -205,3 +205,20 @@
   font-weight: bold;
   font-size: 23px;
 }
+
+.other-images {
+  display: flex;
+}
+
+.other-image {
+  margin-right: 10px;
+  height: 200px;
+  width: 200px;
+}
+
+.image-delete-button {
+  text-align: center;
+  border: solid 1px;
+  cursor: pointer;
+}
+

--- a/app/assets/stylesheets/items/show.css
+++ b/app/assets/stylesheets/items/show.css
@@ -211,9 +211,15 @@
 }
 
 .other-image {
-  margin-right: 10px;
+  margin: 20px 20px 0 0 ;
   height: 200px;
   width: 200px;
+}
+
+.other-image img {
+  height: 100%;
+  width: 100%;
+  object-fit: cover;
 }
 
 .image-delete-button {

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -45,7 +45,7 @@ class ItemsController < ApplicationController
   private
 
   def item_params
-    params.require(:item).permit(:item_name, :item_description, :item_category_id, :item_condition_id, :shipping_cost_id, :shipping_area_id, :delivery_time_id, :image, :price)
+    params.require(:item).permit(:item_name, :item_description, :item_category_id, :item_condition_id, :shipping_cost_id, :shipping_area_id, :delivery_time_id, :price, {images: []})
     .merge(user_id: current_user.id)
   end
 

--- a/app/javascript/preview.js
+++ b/app/javascript/preview.js
@@ -23,8 +23,14 @@ document.addEventListener('turbo:load', function(){
     previewImage.setAttribute('class', 'preview-image');
     previewImage.setAttribute('src', blob);
 
+    // 削除ボタンを生成
+    const deleteButton = document.createElement("div");
+    deleteButton.setAttribute("class", "image-delete-button");
+    deleteButton.innerText = "削除";
+
     // 生成したHTMLの要素をブラウザに表示させる
     previewWrapper.appendChild(previewImage);
+    previewWrapper.appendChild(deleteButton);
     previewList.appendChild(previewWrapper);
 
     // 画像のサイズを設定（幅を50%に変更）

--- a/app/javascript/preview.js
+++ b/app/javascript/preview.js
@@ -10,6 +10,10 @@ document.addEventListener('turbo:load', function(){
   if (!postForm) return null;
   console.log("preview.jsが読み込まれました");
 
+   // 投稿できる枚数の制限を定義
+  const imageLimits = 5;
+
+
 // プレビュー画像を生成・表示する関数
   const buildPreviewImage = (dataIndex, blob) =>{
     
@@ -105,7 +109,10 @@ document.addEventListener('turbo:load', function(){
     };
 
     buildPreviewImage(dataIndex, blob);
-    buildNewFileField();
+    // buildNewFileField();
+    // 画像の枚数制限に引っかからなければ、新しいfile_fieldを追加する
+    const imageCount = document.querySelectorAll(".preview").length;
+    if (imageCount < imageLimits) buildNewFileField();
   };
     // input要素を取得
   const fileField = document.querySelector('input[type="file"][name="item[images][]"]');

--- a/app/javascript/preview.js
+++ b/app/javascript/preview.js
@@ -69,6 +69,16 @@ document.addEventListener('turbo:load', function(){
     const file = e.target.files[0];
     const blob = window.URL.createObjectURL(file);
 
+    // data-indexを使用して、既にプレビューが表示されているかを確認する
+    const alreadyPreview = document.querySelector(`.preview[data-index="${dataIndex}"]`);
+
+    if (alreadyPreview) {
+      // クリックしたfile_fieldのdata-indexと、同じ番号のプレビュー画像が既に表示されている場合は、画像の差し替えのみを行う
+      const alreadyPreviewImage = alreadyPreview.querySelector("img");
+      alreadyPreviewImage.setAttribute("src", blob);
+      return null;
+    };
+
     buildPreviewImage(dataIndex, blob);
     buildNewFileField();
   };

--- a/app/javascript/preview.js
+++ b/app/javascript/preview.js
@@ -9,7 +9,7 @@ document.addEventListener('turbo:load', function(){
   console.log("preview.jsが読み込まれました");
 
   // input要素を取得
-  const fileField = document.querySelector('input[type="file"][name="item[image]"]');
+  const fileField = document.querySelector('input[type="file"][name="item[images][]"]');
   // input要素で値の変化が起きた際に呼び出される関数
   fileField.addEventListener('change', function(e){
     console.log("input要素で値の変化が起きました");
@@ -42,5 +42,14 @@ document.addEventListener('turbo:load', function(){
     // 生成したHTMLの要素をブラウザに表示させる
     previewWrapper.appendChild(previewImage);
     previewList.appendChild(previewWrapper);
+
+    // 2枚目用のfile_fieldを作成
+    const newFileField = document.createElement('input');
+    newFileField.setAttribute('type', 'file');
+    newFileField.setAttribute('name', 'item[images][]');
+
+    // 生成したfile_fieldを表示
+    const fileFieldsArea = document.querySelector('.click-upload');
+    fileFieldsArea.appendChild(newFileField);
   });
 });

--- a/app/javascript/preview.js
+++ b/app/javascript/preview.js
@@ -1,34 +1,18 @@
 document.addEventListener('turbo:load', function(){
   // 新規投稿・編集ページのフォームを取得
   const postForm = document.getElementById('new_post');
+  // プレビューを表示するためのスペースを取得
   const previewList = document.getElementById('previews');
+  // 画像のサイズを設定するためセレクタを取得
   const clickUploadDiv = document.querySelector('.click-upload');
 
   // 新規投稿・編集ページのフォームがないならここで終了。「!」は論理否定演算子。
   if (!postForm) return null;
   console.log("preview.jsが読み込まれました");
 
-  // input要素を取得
-  const fileField = document.querySelector('input[type="file"][name="item[images][]"]');
-  // input要素で値の変化が起きた際に呼び出される関数
-  fileField.addEventListener('change', function(e){
-    console.log("input要素で値の変化が起きました");
-    console.log(e.target.files[0]);
-    const file = e.target.files[0];
-
-    // data-index（何番目を操作しているか）を取得
-    const dataIndex = e.target.getAttribute('data-index');
-    console.log( dataIndex);
-
-    // 古いプレビューが存在する場合は削除
-    const alreadyPreview = document.querySelector('.preview');
-    if (alreadyPreview) {
-      alreadyPreview.remove();
-    };
-
-    const blob = window.URL.createObjectURL(file);
-    console.log(blob);
-
+// プレビュー画像を生成・表示する関数
+  const buildPreviewImage = (dataIndex, blob) =>{
+    
     // 画像を表示するためのdiv要素を生成
     const previewWrapper = document.createElement('div');
     previewWrapper.setAttribute('class', 'preview');
@@ -39,14 +23,18 @@ document.addEventListener('turbo:load', function(){
     previewImage.setAttribute('class', 'preview-image');
     previewImage.setAttribute('src', blob);
 
+    // 生成したHTMLの要素をブラウザに表示させる
+    previewWrapper.appendChild(previewImage);
+    previewList.appendChild(previewWrapper);
+
     // 画像のサイズを設定（幅を50%に変更）
     previewImage.style.width = '50%';
     previewImage.style.height = 'auto'
     clickUploadDiv.style.textAlign = 'center';
+  };
 
-    // 生成したHTMLの要素をブラウザに表示させる
-    previewWrapper.appendChild(previewImage);
-    previewList.appendChild(previewWrapper);
+  // file_fieldを生成・表示する関数
+  const buildNewFileField = () => {
 
     // 2枚目用のfile_fieldを作成
     const newFileField = document.createElement('input');
@@ -62,5 +50,30 @@ document.addEventListener('turbo:load', function(){
     // 生成したfile_fieldを表示
     const fileFieldsArea = document.querySelector('.click-upload');
     fileFieldsArea.appendChild(newFileField);
-  });
+  };
+
+  // input要素で値の変化が起きた際に呼び出される関数の中身
+  const changedFileField = (e) => {
+    // data-index（何番目を操作しているか）を取得
+    const dataIndex = e.target.getAttribute('data-index');
+    console.log( dataIndex);
+
+    // 古いプレビューが存在する場合は削除
+    const alreadyPreview = document.querySelector('.preview');
+    if (alreadyPreview) {
+      alreadyPreview.remove();
+    };
+    const file = e.target.files[0];
+    const blob = window.URL.createObjectURL(file);
+
+    buildPreviewImage(dataIndex, blob);
+    buildNewFileField();
+  };
+    // input要素を取得
+  const fileField = document.querySelector('input[type="file"][name="item[images][]"]');
+  // input要素で値の変化が起きた際に呼び出される関数
+  fileField.addEventListener('change', changedFileField);
+    console.log("input要素で値の変化が起きました");
+    console.log(e.target.files[0]);
+    console.log(blob);
 });

--- a/app/javascript/preview.js
+++ b/app/javascript/preview.js
@@ -28,6 +28,10 @@ document.addEventListener('turbo:load', function(){
     deleteButton.setAttribute("class", "image-delete-button");
     deleteButton.innerText = "削除";
 
+    // 削除ボタンをクリックしたらプレビューとfile_fieldを削除させる
+    deleteButton.addEventListener("click", () => deleteImage(dataIndex));
+
+
     // 生成したHTMLの要素をブラウザに表示させる
     previewWrapper.appendChild(previewImage);
     previewWrapper.appendChild(deleteButton);

--- a/app/javascript/preview.js
+++ b/app/javascript/preview.js
@@ -32,6 +32,7 @@ document.addEventListener('turbo:load', function(){
     // 画像を表示するためのdiv要素を生成
     const previewWrapper = document.createElement('div');
     previewWrapper.setAttribute('class', 'preview');
+    previewWrapper.setAttribute('data-index', dataIndex)
 
     // 表示する画像を生成
     const previewImage = document.createElement('img');

--- a/app/javascript/preview.js
+++ b/app/javascript/preview.js
@@ -47,6 +47,9 @@ document.addEventListener('turbo:load', function(){
     const nextDataIndex = Number(lastFileField.getAttribute('data-index')) +1;
     newFileField.setAttribute('data-index', nextDataIndex);
 
+    // 追加されたfile_fieldにchangeイベントをセット
+    newFileField.addEventListener("change", changedFileField);
+
     // 生成したfile_fieldを表示
     const fileFieldsArea = document.querySelector('.click-upload');
     fileFieldsArea.appendChild(newFileField);

--- a/app/javascript/preview.js
+++ b/app/javascript/preview.js
@@ -75,6 +75,10 @@ document.addEventListener('turbo:load', function(){
     deletePreviewImage.remove();
     const deleteFileField = document.querySelector(`input[type="file"][data-index="${dataIndex}"]`);
     deleteFileField.remove();
+
+    // 画像の枚数が最大のときに削除ボタンを押した場合、file_fieldを1つ追加する
+  const imageCount = document.querySelectorAll(".preview").length;
+  if (imageCount == imageLimits - 1) buildNewFileField();
   };
 
   // input要素で値の変化が起きた際に呼び出される関数の中身

--- a/app/javascript/preview.js
+++ b/app/javascript/preview.js
@@ -16,6 +16,10 @@ document.addEventListener('turbo:load', function(){
     console.log(e.target.files[0]);
     const file = e.target.files[0];
 
+    // data-index（何番目を操作しているか）を取得
+    const dataIndex = e.target.getAttribute('data-index');
+    console.log( dataIndex);
+
     // 古いプレビューが存在する場合は削除
     const alreadyPreview = document.querySelector('.preview');
     if (alreadyPreview) {

--- a/app/javascript/preview.js
+++ b/app/javascript/preview.js
@@ -53,6 +53,12 @@ document.addEventListener('turbo:load', function(){
     newFileField.setAttribute('type', 'file');
     newFileField.setAttribute('name', 'item[images][]');
 
+    // 最後のfile_fieldを取得
+    const lastFileField = document.querySelector('input[type="file"][name="item[images][]"]:last-child');
+    // nextDataIndex = 最後のfile_fieldのdata-index + 1
+    const nextDataIndex = Number(lastFileField.getAttribute('data-index')) +1;
+    newFileField.setAttribute('data-index', nextDataIndex);
+
     // 生成したfile_fieldを表示
     const fileFieldsArea = document.querySelector('.click-upload');
     fileFieldsArea.appendChild(newFileField);

--- a/app/javascript/preview.js
+++ b/app/javascript/preview.js
@@ -62,10 +62,10 @@ document.addEventListener('turbo:load', function(){
     console.log( dataIndex);
 
     // 古いプレビューが存在する場合は削除
-    const alreadyPreview = document.querySelector('.preview');
-    if (alreadyPreview) {
-      alreadyPreview.remove();
-    };
+    // const alreadyPreview = document.querySelector('.preview');
+    // if (alreadyPreview) {
+    //   alreadyPreview.remove();
+    // };
     const file = e.target.files[0];
     const blob = window.URL.createObjectURL(file);
 

--- a/app/javascript/preview.js
+++ b/app/javascript/preview.js
@@ -55,6 +55,14 @@ document.addEventListener('turbo:load', function(){
     fileFieldsArea.appendChild(newFileField);
   };
 
+  // 指定したdata-indexを持つプレビューとfile_fieldを削除する
+  const deleteImage = (dataIndex) => {
+    const deletePreviewImage = document.querySelector(`.preview[data-index="${dataIndex}"]`);
+    deletePreviewImage.remove();
+    const deleteFileField = document.querySelector(`input[type="file"][data-index="${dataIndex}"]`);
+    deleteFileField.remove();
+  };
+
   // input要素で値の変化が起きた際に呼び出される関数の中身
   const changedFileField = (e) => {
     // data-index（何番目を操作しているか）を取得
@@ -67,6 +75,13 @@ document.addEventListener('turbo:load', function(){
     //   alreadyPreview.remove();
     // };
     const file = e.target.files[0];
+
+    // fileが空 = 何も選択しなかったのでプレビュー等を削除して終了する
+    if (!file) {
+      deleteImage(dataIndex);
+      return null;
+    };
+
     const blob = window.URL.createObjectURL(file);
 
     // data-indexを使用して、既にプレビューが表示されているかを確認する

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -12,6 +12,7 @@ class Item < ApplicationRecord
 
   # validates :image, presence: true
   validates :images, presence: true
+  validates :images, length: { minimum: 1, maximum: 5, message: "は1枚以上5枚以下にしてください" }
   validates :item_name, presence: true, length: { maximum: 40 }
   validates :item_description, presence: true,length: { maximum: 1000 }
   validates :price, numericality: { only_integer: true, greater_than_or_equal_to: 300, less_than_or_equal_to: 9999999 }

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -7,9 +7,11 @@ class Item < ApplicationRecord
   belongs_to :delivery_time
   belongs_to :user
   has_one :order
-  has_one_attached :image
+  # has_one_attached :image
+  has_many_attached :images
 
-  validates :image, presence: true
+  # validates :image, presence: true
+  validates :images, presence: true
   validates :item_name, presence: true, length: { maximum: 40 }
   validates :item_description, presence: true,length: { maximum: 1000 }
   validates :price, numericality: { only_integer: true, greater_than_or_equal_to: 300, less_than_or_equal_to: 9999999 }

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -22,7 +22,8 @@ app/assets/stylesheets/items/new.css %>
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%= f.file_field :image, id:"item-image" %>
+        <%# <%= f.file_field :image, id:"item-image" %> 
+        <%= f.file_field :images, id:"item-image", name: 'item[images][]', data: {index: 0} %>
       </div>
     </div>
     <%# /商品画像 %>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -18,7 +18,7 @@ app/assets/stylesheets/items/new.css %>
         <span class="indispensable">必須</span>
       </div>
       <div class="click-upload">
-        <div id="previews"></div>
+        <div id="previews" class="previews"></div>
         <p>
           クリックしてファイルをアップロード
         </p>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -132,7 +132,7 @@
         <li class='list'>
           <%= link_to item_path(item) do %>
           <div class='item-img-content'>
-            <%= image_tag item.image, class: "item-img" %>
+            <%= image_tag item.images[0], class: "item-img" %>
 
             <%# sold outの表示 %>
             <% if Order.exists?(item_id: item.id)%>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -16,7 +16,7 @@
         <span class="indispensable">必須</span>
       </div>
       <div class="click-upload">
-        <div id="previews"></div>
+        <div id="previews" class="previews"></div>
         <p>
           クリックしてファイルをアップロード
         </p>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -20,7 +20,7 @@
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%= f.file_field :image, id:"item-image" %>
+        <%= f.file_field :images, id:"item-image", name: 'post[images][]', data: {index: 0} %>
       </div>
     </div>
     <%# /商品画像 %>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -20,7 +20,8 @@
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%= f.file_field :images, id:"item-image", name: 'post[images][]', data: {index: 0} %>
+        <%# <%= f.file_field :image, id:"item-image" %>
+        <%= f.file_field :images, id:"item-image", name: 'item[images][]', data: {index: 0} %>
       </div>
     </div>
     <%# /商品画像 %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -7,7 +7,14 @@
       <%= @item.item_name %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag @item.image ,class:"item-box-img" %>
+      <%= image_tag @item.images[0], class: "item-box-img" %><br>
+      <div class="other-images">
+        <% @item.images[1..-1].each do |image| %>
+          <div class="other-image">
+            <%= image_tag image %>
+          </div>
+        <%end%>
+    </div>
       <%# sold outの表示 %>
       <% if Order.exists?(item_id: @item.id)%>
         <div class="sold-out">


### PR DESCRIPTION
# WHAT
商品出品時、出品した商品の編集時に複数枚画像の投稿機能とそのプレビュー表示機能を実装
・5枚を上限に複数枚画像を選択することができ、それぞれプレビュー表示がされる
・画像の選び直し・削除も可能

 # WHY
商品を出品する際に複数枚画像の投稿機能とそのプレビュー表示機能を実装するメリットは以下のものが挙げられます

・商品の詳細な説明:
複数の画像を使用することで、商品を多角的に示すことができます。例えば、商品の全体像、特定のディテール、使用方法、商品のサイズ感など、異なる視点からユーザーに示すことができ、商品の理解度を深めます。
・購入意欲の向上:
顧客は商品を購入する前にその実物をしっかり確認したいと考えています。高品質な画像と多様なアングルの提示は、購入意欲を高め、成約率を向上させる要因となります。
・選び直しの利便性:
画像選び直しの機能があることで、出品者は誤って選択した画像を簡単に変更でき、自分が求める最適な画像を提供できます。この機能は、出品者のストレスを軽減し、投稿プロセスをよりスムーズにします。
・視覚的な魅力の強化:
複数の画像がユーザーの目を引き、商品リスト内での視覚的な魅力を強化します。特にオンライン市場では、魅力的なビジュアルが競争力を高める重要な要素です。
・エラーの低減:
プレビュー表示によって、出品者は自分が選択した画像が実際にどのように投稿されるかを事前に確認でき、誤入力や選択ミスを防ぐことができます。これにより出品後の修正手間も減ります。
・競争力の向上:
他の出品者と比較して、豊富な画像を持つ商品は注目を集めやすく、新規の顧客を引き寄せる可能性が高まります。この結果、より高い販売機会を得ることができます。